### PR TITLE
README.mdのコードブロックに言語を指定する件

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Markdown から日本企業っぽいメールに変換します。
 
 `npm install @anydown/maildown`
 
-```
+```js
 const maildown = require("@anydown/maildown");
 
 const converted = maildown(`## test


### PR DESCRIPTION
いつもお世話になっております。

maildownがnpmで利用できるようになったこと、誠に喜ばしく思います。
npmパッケージ化にともない、
`README.md`にサンプルコードを掲載されていることと存じますが、
GitHubではコードブロックに言語を指定することで、
シンタックスハイライトが有効になります。
突然のプルリクエストで恐縮ではございますが、マージをご検討ください。

以上、よろしくお願いいたします。